### PR TITLE
Ensure downloads use original-resolution crop

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,11 +159,13 @@
     });
 
     saveBtn.addEventListener('click', ()=>{
-      const out=document.createElement('canvas'); out.width=canvas.width; out.height=canvas.height;
+      const out=document.createElement('canvas');
+      out.width=Math.round(canvas.width/scale);
+      out.height=Math.round(canvas.height/scale);
       const octx=out.getContext('2d');
-      octx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
+      octx.translate(offsetX/scale + img.width/2, offsetY/scale + img.height/2);
       octx.rotate(rotation);
-      octx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
+      octx.drawImage(img, -img.width/2, -img.height/2);
       out.toBlob(blob=>{
         const link=document.createElement('a');
         link.download=filename+'_zuschnitt.jpg';
@@ -173,11 +175,13 @@
 
     function copyCrop(){
       if(!img.src) return;
-      const out=document.createElement('canvas'); out.width=canvas.width; out.height=canvas.height;
+      const out=document.createElement('canvas');
+      out.width=Math.round(canvas.width/scale);
+      out.height=Math.round(canvas.height/scale);
       const octx=out.getContext('2d');
-      octx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
+      octx.translate(offsetX/scale + img.width/2, offsetY/scale + img.height/2);
       octx.rotate(rotation);
-      octx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
+      octx.drawImage(img, -img.width/2, -img.height/2);
       out.toBlob(async blob=>{
         try{
           await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);


### PR DESCRIPTION
## Summary
- export cropped images at original resolution instead of preview size
- copy to clipboard using original-resolution crop
- correct crop translation so exports align with preview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891cee2d7bc8325bd76e958151695fd