### PR TITLE
Fix crop scaling for download and clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,30 +159,18 @@
     });
 
     saveBtn.addEventListener('click', ()=>{
-      const out=document.createElement('canvas');
-      out.width=Math.round(canvas.width/scale);
-      out.height=Math.round(canvas.height/scale);
-      const octx=out.getContext('2d');
-      octx.translate((-offsetX)/scale + img.width/2, (-offsetY)/scale + img.height/2);
-      octx.rotate(rotation);
-      octx.drawImage(img, -img.width/2, -img.height/2);
-      out.toBlob(blob=>{
+      canvas.toBlob(blob=>{
         const link=document.createElement('a');
         link.download=filename+'_zuschnitt.jpg';
-        link.href=URL.createObjectURL(blob); link.click(); URL.revokeObjectURL(link.href);
+        link.href=URL.createObjectURL(blob);
+        link.click();
+        URL.revokeObjectURL(link.href);
       },'image/jpeg');
     });
 
     function copyCrop(){
       if(!img.src) return;
-      const out=document.createElement('canvas');
-      out.width=Math.round(canvas.width/scale);
-      out.height=Math.round(canvas.height/scale);
-      const octx=out.getContext('2d');
-      octx.translate((-offsetX)/scale + img.width/2, (-offsetY)/scale + img.height/2);
-      octx.rotate(rotation);
-      octx.drawImage(img, -img.width/2, -img.height/2);
-      out.toBlob(async blob=>{
+      canvas.toBlob(async blob=>{
         try{
           await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);
         }catch(err){


### PR DESCRIPTION
## Summary
- Generate downloads and clipboard copies directly from the displayed canvas
- Removes vertical offset and black bar when saving or copying crops

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891d839bae48325ab23796d7b5c9c94