### PR TITLE
Export full-resolution crop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Dies ist eine kleine Webanwendung zum Zuschneiden von Bildern auf ein 21:9 Seite
 * Bilder können per "Bild laden"-Button, Drag & Drop oder Einfügen aus der Zwischenablage geladen werden.
 * Das Bild lässt sich per Maus verschieben und mit dem Mausrad zoomen.
 * über den Schieberegler kann das Bild gedreht werden.
-* Durch Klick auf **Speichern** wird der aktuelle Bildausschnitt als JPEG heruntergeladen.
+* Durch Klick auf **Speichern** wird der aktuelle Bildausschnitt als JPEG in Originalauflösung heruntergeladen.
+* Über **Ausschnitt kopieren** wird derselbe Ausschnitt in Originalgröße in die Zwischenablage kopiert.
 
 ## Verwendung
 Einfach die `index.html` in einem modernen Browser öffnen und ein Bild auswählen oder in den markierten Bereich ziehen.

--- a/index.html
+++ b/index.html
@@ -158,12 +158,20 @@
       draw();
     });
 
-    saveBtn.addEventListener('click', ()=>{
-      const out=document.createElement('canvas'); out.width=canvas.width; out.height=canvas.height;
+    function createOutputCanvas(){
+      const exportScale = 1/scale;
+      const out=document.createElement('canvas');
+      out.width=Math.round(canvas.width*exportScale);
+      out.height=Math.round(canvas.height*exportScale);
       const octx=out.getContext('2d');
-      octx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
+      octx.translate(offsetX*exportScale + img.width/2, offsetY*exportScale + img.height/2);
       octx.rotate(rotation);
-      octx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
+      octx.drawImage(img, -img.width/2, -img.height/2);
+      return out;
+    }
+
+    saveBtn.addEventListener('click', ()=>{
+      const out=createOutputCanvas();
       out.toBlob(blob=>{
         const link=document.createElement('a');
         link.download=filename+'_zuschnitt.jpg';
@@ -173,11 +181,7 @@
 
     function copyCrop(){
       if(!img.src) return;
-      const out=document.createElement('canvas'); out.width=canvas.width; out.height=canvas.height;
-      const octx=out.getContext('2d');
-      octx.translate(offsetX + img.width*scale/2, offsetY + img.height*scale/2);
-      octx.rotate(rotation);
-      octx.drawImage(img, -img.width*scale/2, -img.height*scale/2, img.width*scale, img.height*scale);
+      const out=createOutputCanvas();
       out.toBlob(async blob=>{
         try{
           await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);


### PR DESCRIPTION
## Summary
- export crop in original resolution for both save and copy actions
- update docs to reflect full-resolution exporting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689376bece9c83259034eb51b55bc699