### PR TITLE
Fix history append behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,9 +172,6 @@
     function addImageToHistory(src, name) {
       if(!src) return;
       updateHistoryState();
-      if(historyIndex < imageHistory.length - 1) {
-        imageHistory = imageHistory.slice(0, historyIndex + 1);
-      }
       imageHistory.push({ src, name, state: null });
       historyIndex = imageHistory.length - 1;
       initImage(src, name);
@@ -366,4 +363,3 @@
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- Adding a new image while viewing an earlier history entry previously removed later entries; the desired behavior is to append new images to the end and keep existing entries intact.

### Description
- Removed the truncation logic in `addImageToHistory` that sliced `imageHistory` when `historyIndex < imageHistory.length - 1`, so new images are always pushed and `historyIndex` is set to the last entry.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a05e18cdc832585420d4c718677a3)